### PR TITLE
Changes for S3-118 + improve cache list

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -24,8 +24,35 @@
     import { exists, createDir, BaseDirectory } from '@tauri-apps/api/fs';
     import type { Runner } from "./lib/models/Kernel";
     import { activeTab } from "./lib/data/Stores";
+    import Tooltip from "./components/Tooltip.svelte";
+    import { getVersion } from "@tauri-apps/api/app";
     
-    let tabs = ["File", "Preprocessor", "Results", "Help"]
+    let tabs = [
+        {
+            name: "File",
+            disabled: () => {
+                return false
+            }
+        }, 
+        {
+            name: "Preprocessor",
+            disabled: () => {
+                return ProjectSingleton.GetInstance().IsValid() == false
+            }
+        }, 
+        {
+            name: "Results",
+            disabled: () => {
+                return ProjectSingleton.GetInstance().IsValid() == false
+            }
+        }, 
+        {
+            name: "Help",
+            disabled: () => {
+                return false
+            }
+        }, 
+    ]
     let unsaved = true
     let activeAlerts: any[] = []
 
@@ -43,6 +70,9 @@
         if (!folderExists) {
             await createDir('Projects', { dir: BaseDirectory.Document, recursive: true})
         }
+
+        // Update version to released version
+        version = await getVersion()
     })
 
     const minimizeButton = {
@@ -81,6 +111,8 @@
 
     ProjectSingleton.GetInstance().Subscribe((v) => {
         loadedProjectName = v.name
+        // Refresh hack to force re-render
+        tabs = [...tabs]
     })
 </script>
 
@@ -107,7 +139,7 @@
                     SimSUNDT {version}
                 </div>
             </div>
-            <div data-tauri-drag-region class="flex flex-row mt-2 text-xs cursor-default select-none">{loadedProjectName}</div>
+            <div data-tauri-drag-region class="flex flex-row mt-2 text-xs cursor-default select-none">{ProjectSingleton.GetInstance().IsValid() ? loadedProjectName : 'No active project'}</div>
             <div class="flex flex-row ml-auto -mr-3" style="z-index: 99">
                 <!-- Minimize -->
                 <div class="flex flex-col w-full px-1 rounded-b hover:bg-stone-400">
@@ -135,10 +167,16 @@
         <ul class="flex flex-row">
             {#each tabs as tab}
                 <li class="mr-2">
-                    {#if $activeTab == tab}
-                        <button class="inline-block text-gray-200 rounded-t-lg border-b-2 border-yellow-600 active">{tab}</button>
+                    {#if $activeTab == tab.name}
+                        <button class="inline-block text-gray-200 rounded-t-lg border-b-2 border-yellow-600 active">{tab.name}</button>
                     {:else}
-                        <button class="inline-block rounded-t-lg border-b-2 border-transparent hover:text-gray-600 hover:border-gray-300 dark:hover:text-gray-300" on:click={() => $activeTab = tab}>{tab}</button>
+                        {#if tab.disabled() == true}
+                            <Tooltip label="Project must be loaded" class="text-xs text-white">
+                                <button class="inline-block rounded-t-lg border-b-2 border-transparent text-gray-400 dark:text-gray-300 opacity-75 text-sm">{tab.name}</button>
+                            </Tooltip>
+                        {:else}
+                            <button class="inline-block text-gray-200 rounded-t-lg border-b-2 border-transparent hover:text-gray-600 hover:border-gray-300 dark:hover:text-gray-300" on:click={() => $activeTab = tab.name}>{tab.name}</button>
+                        {/if}
                     {/if}
                 </li>
             {/each}
@@ -163,7 +201,7 @@
     <div class="mx-auto w-6/12 mt-12 cursor-default" style="position: absolute; left: 0; right: 0; top: 0; z-index: 999;">
         {#each activeAlerts as alert}
         <div class="mt-0.5" transition:slide>
-            <Alert text={alert.t} color={alert.c} icon={alert.i}/>
+            <Alert text={alert.t} color={alert.c} icon={alert.i} duration={alert.duration}/>
         </div>
         {/each}
     </div>

--- a/src/components/Alert.svelte
+++ b/src/components/Alert.svelte
@@ -1,7 +1,27 @@
 <script lang="ts">
+    import { onMount } from "svelte";
+
     export let text: string
     export let color: string
     export let icon: string
+    export let duration: number | null = null
+    let timeLeft: number | null = duration
+
+    onMount(() => {
+        if (duration) {
+            const interval = setInterval(() => {
+                if (timeLeft === null) {
+                    clearInterval(interval)
+                    return
+                }
+
+                timeLeft = timeLeft - 0.1
+                if (timeLeft <= 0) {
+                    clearInterval(interval)
+                }
+            }, 100)
+        }
+    })
 </script>
 
 <div class="flex flex-col">
@@ -12,6 +32,16 @@
         <div class="flex flex-col px-2 my-2">
             <p>{text}</p>
         </div>
+        {#if duration}
+        <!-- Countdown circle -->
+        <div class="flex flex-col ml-auto mr-2">
+            <div class="flex flex-col rounded-full bg-stone-400 w-6 h-6 items-center justify-center">
+                <p class="text-xs">
+                    {timeLeft?.toFixed(0)}
+                </p>
+            </div>
+        </div>
+        {/if}
     </div>
 </div>
 

--- a/src/components/Tooltip.svelte
+++ b/src/components/Tooltip.svelte
@@ -3,15 +3,14 @@
     export let disabled: boolean = false
     let visible: boolean
     let parent: HTMLDivElement
-    let width: number
 </script>
 
-<div class="flex flex-col w-full items-center" on:pointerenter={() => visible = true} on:pointerleave={() => visible = false} bind:this={parent}>
+<div class="flex flex-col w-full items-center {$$restProps.class || ''}" on:pointerenter={() => visible = true} on:pointerleave={() => visible = false} bind:this={parent}>
     {#if visible && !disabled}
     <svg width="24" height="24" style="position: absolute;" viewBox="0 0 500 500" class="mt-3.5">
         <polygon points="250,60 100,400 400,400" fill="#ED9E14" />
     </svg>
-    <div style="position: absolute; left: {parent.offsetLeft - width / 2}px; top: {parent.offsetTop}; z-index: 999; white-space: pre-wrap" class="bg-amber-500 rounded px-2 py-1 mt-8" bind:clientWidth={width}>
+    <div style="position: absolute; top: {parent.offsetTop}; z-index: 999; white-space: pre-wrap" class="bg-amber-500 rounded px-2 py-1 mt-8">
         {label}
     </div>
     {/if}

--- a/src/components/modals/NewProjectModal.svelte
+++ b/src/components/modals/NewProjectModal.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+    import { open } from "@tauri-apps/api/dialog";
+    import type { Button as IButton } from "../../lib/models/Button";
+    import Button from "../Button.svelte";
+    import Modal from "../Modal.svelte";
+    import { onMount } from "svelte";
+    import { SIMSUNDT_PROJECT_FOLDER } from "../../lib/models/PresetPaths";
+    import { ProjectSingleton } from "../../lib/data/ProjectSingleton";
+    import { activeTab } from "../../lib/data/Stores";
+    
+
+    export let isOpen: boolean
+    let width: number 
+    let height: number
+    let name: string = "New project"
+    let directory: string = ""
+
+    onMount(() => {
+        // Set initial directory to the user's documents folder
+        directory = SIMSUNDT_PROJECT_FOLDER
+    })
+
+    let cancelButton: IButton = {
+        color: "#ba3822", 
+        icon: "close", 
+        label: "Cancel", 
+        labelSize: 14, 
+        action: () => {
+            isOpen = false
+        }
+    }
+
+    let createButton: IButton = {
+        color: "#55b13c", 
+        icon: "input", 
+        label: "Create", 
+        labelSize: 14, 
+        action: async () => {
+            let pj = ProjectSingleton.GetInstance()
+
+            // Create a new project using New in the projectSingleton
+            await pj.New()
+
+            // Save the project in the destination directory + project name
+            pj.Save(directory + "\\" + name + ".ssproj").then(() => {
+                isOpen = false
+                activeTab.set("Preprocessor")
+            }).catch((err) => {
+                console.error(err)
+            })
+        }
+    }
+
+    const handleOpenSaveLocation = () => {
+        // Open dialog to select save location
+        open({
+            multiple: false,
+            directory: true
+        }).then((chosenPath) => {
+            if (chosenPath === null || Array.isArray(chosenPath)) return
+            directory = chosenPath
+        }).catch((err) => {
+            return
+        })
+    }
+</script>
+
+<svelte:window bind:innerWidth={width} bind:innerHeight={height} />
+<Modal bind:isOpen={isOpen} label="New project" description={"Creates a new project"} width={width < 1340 ? 6 : 4 } height={height < 900 ? 6 : 4}>
+    <!-- Project name -->
+    <div class="flex flex-row w-full">
+        <div class="flex flex-col ml-3 pb-3 w-full">
+            <label for="new_project_name" class="block text-sm font-medium text-gray-900 dark:text-white" style="color:#4d4d4d;">Project name</label>
+            <input id="new_project_name" class="w-full bg-gray-50 border-2 border-transparent text-gray-900 text-sm rounded-lg focus:outline-none focus:ring-0 disabled:opacity-75"
+                bind:value={name}/>
+        </div>
+    </div>
+    <!-- Save location -->
+    <div class="flex flex-row w-full pb-1">
+        <div class="flex flex-col w-full mx-3">
+            <label for="new_project_location" class="block text-sm font-medium text-gray-900 dark:text-white" style="color:#4d4d4d;">Save location</label>
+            <div class="flex flex-row w-full items-center justify-center">
+                <div class="flex flex-col w-full">
+                    <input id="new_project_location" class="w-full bg-gray-50 border-2 border-transparent text-gray-900 text-sm rounded-lg focus:outline-none focus:ring-0 disabled:opacity-75"
+                        bind:value={directory}/>
+                </div>
+                <div class="flex flex-col pl-3">
+                    <Button data={{ color: "#4d4d4d", icon: "folder_open", action: handleOpenSaveLocation }}/>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Cancel/create -->
+    <div class="flex flex-row w-full p-3">
+        <div class="flex flex-col rounded px-2 py-1 hover:bg-stone-50 mr-auto">
+            <Button data={cancelButton}/>
+        </div>
+        <div class="flex flex-col rounded px-2 py-1 hover:bg-stone-50 ml-auto">
+            <Button data={createButton}/>
+        </div>
+    </div>
+</Modal>

--- a/src/lib/data/ProjectCacheSingleton.ts
+++ b/src/lib/data/ProjectCacheSingleton.ts
@@ -34,7 +34,7 @@ export class ProjectCacheSingleton {
             if (element.path === project.path) {
                 element.name = project.name
                 element.date = new Date()
-                element.results = project.data.postprocessor.length
+                element.results = project.data.postprocessor?.length
                 hit = true
             }
         })
@@ -44,7 +44,7 @@ export class ProjectCacheSingleton {
                 name: project.name,
                 path: project.path,
                 date: new Date(),
-                results: project.data.postprocessor.length
+                results: project.data.postprocessor?.length
             })
         }
 

--- a/src/lib/data/ProjectCacheSingleton.ts
+++ b/src/lib/data/ProjectCacheSingleton.ts
@@ -34,6 +34,7 @@ export class ProjectCacheSingleton {
             if (element.path === project.path) {
                 element.name = project.name
                 element.date = new Date()
+                element.results = project.data.postprocessor.length
                 hit = true
             }
         })
@@ -42,7 +43,8 @@ export class ProjectCacheSingleton {
             this.projects.push({
                 name: project.name,
                 path: project.path,
-                date: new Date()
+                date: new Date(),
+                results: project.data.postprocessor.length
             })
         }
 

--- a/src/lib/data/ProjectSingleton.ts
+++ b/src/lib/data/ProjectSingleton.ts
@@ -51,6 +51,10 @@ export class ProjectSingleton {
         return this._store.subscribe(fnc)
     }
 
+    public IsValid(): boolean {
+        return this._active.path !== null
+    }
+
     public async New(): Promise<void> {
         this._active = {
             name: "Untitled Project",

--- a/src/lib/models/Cache.ts
+++ b/src/lib/models/Cache.ts
@@ -1,5 +1,6 @@
 export interface ProjectCache {
     name: string,
     path: string,
-    date: Date
+    date: Date,
+    results: number
 }

--- a/src/tabs/File.svelte
+++ b/src/tabs/File.svelte
@@ -8,12 +8,15 @@
     import { exists } from '@tauri-apps/api/fs';
     import ImportModal from '../components/modals/ImportModal.svelte';
     import { activeTab } from '../lib/data/Stores';
+    import NewProjectModal from '../components/modals/NewProjectModal.svelte';
+    import Tooltip from '../components/Tooltip.svelte';
 
     export let unsaved
     export let activeAlerts: any
 
     let projectSingleton: ProjectSingleton = ProjectSingleton.GetInstance()
     let cacheSingleton: ProjectCacheSingleton = ProjectCacheSingleton.GetInstance()
+    let isNewProjectModalOpen: boolean = false
     let isImportModalOpen: boolean = false
 
     onMount(async () => {
@@ -22,7 +25,7 @@
     })
 
     async function addNewAlert(text: any, color: any, icon: any, timeout: any) {
-        activeAlerts.push({t: text, c: color, i: icon})
+        activeAlerts.push({t: text, c: color, i: icon, duration: null })
 
         setTimeout(() => {
             let idx = -1
@@ -98,7 +101,7 @@
             addNewAlert("Something went wrong when attempting to save, please try again.", "#ef4444", "warning", 6000)
         })
     }
-//
+
     async function handleOpenSaveModal() {
         const saveResult: string | null = await save({
             filters: [{
@@ -119,12 +122,8 @@
     }
 
     async function createNewProject() {
-        await projectSingleton.New().then(() => {
-            activeTab.set("Preprocessor")
-            unsaved = true
-        }).catch(() => {
-            addNewAlert("Something went wrong when attempting to create new project, please try again.", "#ef4444", "warning", 6000)
-        })
+        // Open create project modal
+        isNewProjectModalOpen = true
     }
 
     projectSingleton.Subscribe((v) => {
@@ -202,14 +201,26 @@
                 </div>
                 <div class="flex flex-row border-2 rounded-lg w-full"/>
                 <div class="flex flex-col w-full latest-projects pr-1 mt-1"  style="overflow: auto">
-                    {#each cacheSingleton.projects as project}
+                    {#each cacheSingleton.projects.sort((a, b) => { return a.date > b.date ? -1 : 1 }).slice(0,6) as project}
                     <div class="flex flex-row rounded-md shadow-md w-full bg-stone-300 py-2 my-1 hover:bg-gray-100" transition:slide|local> 
-                        <a href="#" class="flex flex-row w-full" on:click={(e) => handleLoadByName(project)}>
+                        <a href="#" class="flex flex-row w-full items-center" on:click={(e) => handleLoadByName(project)}>
                             <div class="flex flex-col ml-2">
                                 <p class="font-lg text-simsundt-gray">{project.name}</p>
+                                <p class="font-lg text-sm text-simsundt-gray">{new Date(project.date).toLocaleString()}</p>
                             </div>
+                            <!-- Stylized badge indicator of how many simulations results are in the project -->
                             <div class="flex flex-col ml-auto mr-2">
-                                <p class="font-lg text-simsundt-gray">{project.date.toLocaleString()}</p>
+                                <div class="flex flex-col rounded-full bg-yellow-600 w-6 h-6 items-center justify-center">
+                                    <Tooltip label="Number of results in project" class="text-xs text-white"> 
+                                        <p class="text-xs">
+                                            {#if project.results !== undefined}
+                                                {project.results}
+                                            {:else}
+                                                ?
+                                            {/if}
+                                        </p>
+                                    </Tooltip>
+                                </div>
                             </div>
                         </a>
                     </div>
@@ -219,6 +230,7 @@
         </div>
     </div>
     <ImportModal bind:isOpen={isImportModalOpen}/>
+    <NewProjectModal bind:isOpen={isNewProjectModalOpen}/>
 </div>
 
 <style>
@@ -246,7 +258,7 @@
     }
     .latest-projects {
         min-height: 100px;
-        max-height: calc(100vh - 500px);
+        max-height: calc(100vh - 545px);
     }
     ::-webkit-scrollbar {
         width: 14px;


### PR DESCRIPTION
Provides a new dialog when clicking new project to prevent any simulation runs with an unsaved project. This should solve users losing results if they accidentally close the application with a result in an unloaded project.

S3-118 and S3-90

Also some minor improvements:
- Cache list now has an indicator of how many results are in a project
- Dates are fixed, no more unformatted dates in cache list.
- Actual version is now displayed to the right of "SimSUNDT" in the top left corner