### PR TITLE
S3-89

### DIFF
--- a/src-tauri/resources/presets.json
+++ b/src-tauri/resources/presets.json
@@ -1,0 +1,249 @@
+[
+    {
+        "name": "AM2R-14X14-45",
+        "manufacturer": "Olympus",
+        "manufacturerHref": "https://www.olympus-ims.com/",
+        "datasheetHref": "https://www.olympus-ims.com/en/.downloads/download/?file=285213062&fl=en_US",
+        "frequency": "2",
+        "pb": "45",
+        "angle": "45",
+        "dimensions": {
+            "x": "14",
+            "y": "14"
+        }
+    },
+    {
+        "name": "AM2R-14X14-60",
+        "manufacturer": "Olympus",
+        "manufacturerHref": "https://www.olympus-ims.com/",
+        "datasheetHref": "https://www.olympus-ims.com/en/.downloads/download/?file=285213063&fl=en_US",
+        "frequency": "2",
+        "pb": "45",
+        "angle": "60",
+        "dimensions": {
+            "x": "14",
+            "y": "14"
+        }
+    },
+    {
+        "name": "AM2R-20X22-45",
+        "manufacturer": "Olympus",
+        "manufacturerHref": "https://www.olympus-ims.com/",
+        "datasheetHref": "https://www.olympus-ims.com/en/.downloads/download/?file=285213066&fl=en_US",
+        "frequency": "2",
+        "pb": "40",
+        "angle": "45",
+        "dimensions": {
+            "x": "20",
+            "y": "22"
+        }
+    },
+    {
+        "name": "AM4R-20X22-45",
+        "manufacturer": "Olympus",
+        "manufacturerHref": "https://www.olympus-ims.com/",
+        "datasheetHref": "https://www.olympus-ims.com/en/.downloads/download/?file=285213072&fl=en_US",
+        "frequency": "4",
+        "pb": "40",
+        "angle": "45",
+        "dimensions": {
+            "x": "20",
+            "y": "22"
+        }
+    },
+    {
+        "name": "AM4R-20X22-60",
+        "manufacturer": "Olympus",
+        "manufacturerHref": "https://www.olympus-ims.com/",
+        "datasheetHref": "https://www.olympus-ims.com/en/.downloads/download/?file=285213073&fl=en_US",
+        "frequency": "4",
+        "pb": "40",
+        "angle": "60",
+        "dimensions": {
+            "x": "20",
+            "y": "22"
+        }
+    },
+    {
+        "name": "AM2R-8X9-45",
+        "manufacturer": "Olympus",
+        "manufacturerHref": "https://www.olympus-ims.com/",
+        "datasheetHref": "https://www.olympus-ims.com/en/.downloads/download/?file=285213069&fl=en_US",
+        "frequency": "2",
+        "pb": "40",
+        "angle": "45",
+        "dimensions": {
+            "x": "8",
+            "y": "9"
+        }
+    },
+    {
+        "name": "AM2R-8X9-60",
+        "manufacturer": "Olympus",
+        "manufacturerHref": "https://www.olympus-ims.com/",
+        "datasheetHref": "https://www.olympus-ims.com/en/.downloads/download/?file=285213070&fl=en_US",
+        "frequency": "2",
+        "pb": "40",
+        "angle": "60",
+        "dimensions": {
+            "x": "8",
+            "y": "9"
+        }
+    },
+    {
+        "name": "CN2R-10",
+        "manufacturer": "Olympus",
+        "manufacturerHref": "https://www.olympus-ims.com/",
+        "datasheetHref": null,
+        "frequency": "2",
+        "pb": "85",
+        "angle": "0",
+        "dimensions": {
+            "x": "10",
+            "y": "0"
+        }
+    },
+    {
+        "name": "CN2R-24",
+        "manufacturer": "Olympus",
+        "manufacturerHref": "https://www.olympus-ims.com/",
+        "datasheetHref": null,
+        "frequency": "2",
+        "pb": "85",
+        "angle": "0",
+        "dimensions": {
+            "x": "24",
+            "y": "0"
+        }
+    },
+    {
+        "name": "CN4R-10",
+        "manufacturer": "Olympus",
+        "manufacturerHref": "https://www.olympus-ims.com/",
+        "datasheetHref": null,
+        "frequency": "4",
+        "pb": "85",
+        "angle": "0",
+        "dimensions": {
+            "x": "10",
+            "y": "0"
+        }
+    },
+    {
+        "name": "CN4R-24",
+        "manufacturer": "Olympus",
+        "manufacturerHref": "https://www.olympus-ims.com/",
+        "datasheetHref": null,
+        "frequency": "4",
+        "pb": "91",
+        "angle": "0",
+        "dimensions": {
+            "x": "24",
+            "y": "0"
+        }
+    },
+    {
+        "name": "CN5R-5",
+        "manufacturer": "Olympus",
+        "manufacturerHref": "https://www.olympus-ims.com/",
+        "datasheetHref": null,
+        "frequency": "5",
+        "pb": "60",
+        "angle": "0",
+        "dimensions": {
+            "x": "5",
+            "y": "0"
+        }
+    },
+    {
+        "name": "14692-1001",
+        "manufacturer": "IMASONIC",
+        "manufacturerHref": "https://www.imasonic.com/",
+        "datasheetHref": null,
+        "frequency": "10",
+        "pb": "90",
+        "angle": "0",
+        "dimensions": {
+            "x": "35",
+            "y": "0"
+        }
+    },
+    {
+        "name": "SONOSCAN WS 45-2 EN",
+        "manufacturer": "SONOTEC",
+        "manufacturerHref": "https://www.sonotec.eu/",
+        "datasheetHref": null,
+        "frequency": "2",
+        "pb": "35",
+        "angle": "45",
+        "dimensions": {
+            "x": "8",
+            "y": "9"
+        }
+    },
+    {
+        "name": "SONOSCAN WS 60-2 EN",
+        "manufacturer": "SONOTEC",
+        "manufacturerHref": "https://www.sonotec.eu/",
+        "datasheetHref": null,
+        "frequency": "2",
+        "pb": "35",
+        "angle": "60",
+        "dimensions": {
+            "x": "8",
+            "y": "9"
+        }
+    },
+    {
+        "name": "SONOSCAN WS 60-4 EN",
+        "manufacturer": "SONOTEC",
+        "manufacturerHref": "https://www.sonotec.eu/",
+        "datasheetHref": null,
+        "frequency": "4",
+        "pb": "35",
+        "angle": "60",
+        "dimensions": {
+            "x": "8",
+            "y": "9"
+        }
+    },
+    {
+        "name": "SONOSCAN WS 45-4 EN",
+        "manufacturer": "SONOTEC",
+        "manufacturerHref": "https://www.sonotec.eu/",
+        "datasheetHref": null,
+        "frequency": "4",
+        "pb": "35",
+        "angle": "45",
+        "dimensions": {
+            "x": "8",
+            "y": "9"
+        }
+    },
+    {
+        "name": "SONOSCAN WM 45-2 EN",
+        "manufacturer": "SONOTEC",
+        "manufacturerHref": "https://www.sonotec.eu/",
+        "datasheetHref": null,
+        "frequency": "2",
+        "pb": "35",
+        "angle": "45",
+        "dimensions": {
+            "x": "14",
+            "y": "14"
+        }
+    },
+    {
+        "name": "SONOSCAN WM 60-2 EN",
+        "manufacturer": "SONOTEC",
+        "manufacturerHref": "https://www.sonotec.eu/",
+        "datasheetHref": null,
+        "frequency": "2",
+        "pb": "35",
+        "angle": "60",
+        "dimensions": {
+            "x": "14",
+            "y": "14"
+        }
+    }
+]

--- a/src/components/Tree.svelte
+++ b/src/components/Tree.svelte
@@ -39,6 +39,8 @@
         if (kernelValidator && (node instanceof TreeInput || node instanceof TreeCheckbox || node instanceof TreeDropdown)) {
             validationResult = kernelValidator.Validate((parentRef + node.name).replace(/\W/g, ""), node.value)
         }
+        // Trigger a re-render of node
+        node = node
     })
 
     onMount(() => {

--- a/src/components/modals/PresetProbesModal.svelte
+++ b/src/components/modals/PresetProbesModal.svelte
@@ -1,0 +1,139 @@
+<script lang="ts">
+    import { onMount } from "svelte";
+    import type { Button as IButton } from "../../lib/models/Button";
+    import Button from "../Button.svelte";
+    import Modal from "../Modal.svelte";
+    import { PresetsSingleton } from "../../lib/data/PresetsSingleton";
+    import type { Preset } from "../../lib/models/Preset";
+    import { ProjectSingleton } from "../../lib/data/ProjectSingleton";
+    import type { TreeInput } from "../../lib/models/tree/TreeInput";
+
+    export let isOpen: boolean = false
+    let width: number
+    let height: number
+    let selectedPreset: Preset | null = null
+
+    let visitwebsiteButton: IButton = {
+        color: "#55b13c", 
+        icon: "open_in_new", 
+        label: "Manufacturer website", 
+        labelSize: 14, 
+        action: () => {
+            if (selectedPreset == null || selectedPreset.manufacturerHref == null) return
+            window.open(selectedPreset?.manufacturerHref, "_blank")
+        },
+        disabled: true
+    }
+
+    let avgDgsDiagramButton: IButton = {
+        color: "#55b13c", 
+        icon: "show_chart", 
+        label: "AVG/DGS diagram", 
+        labelSize: 14, 
+        action: () => {
+            if (selectedPreset == null || selectedPreset.datasheetHref == null) return
+            window.open(selectedPreset?.datasheetHref, "_blank")
+        },
+        disabled: true
+    }
+
+    let cancelButton: IButton = {
+        color: "#ba3822", 
+        icon: "close", 
+        label: "Cancel", 
+        labelSize: 14, 
+        action: () => {
+            isOpen = false
+        }
+    }
+
+    let applyButton: IButton = {
+        color: "#55b13c", 
+        icon: "input", 
+        label: "Apply", 
+        labelSize: 14, 
+        action: () => {
+            if (selectedPreset == null) return
+
+            // Update the projectSingleton tree with the selected preset information
+            let freq = ProjectSingleton.GetInstance().Tree?.FindChildByPattern("Transmitter:Spectrum:Frequency") as TreeInput
+            let bw = ProjectSingleton.GetInstance().Tree?.FindChildByPattern("Transmitter:Spectrum:Bandwidth") as TreeInput
+            let angle = ProjectSingleton.GetInstance().Tree?.FindChildByPattern("Transmitter:BeamAngles:Angle") as TreeInput
+            let dimX = ProjectSingleton.GetInstance().Tree?.FindChildByPattern("Transmitter:ShapeandElements:X:Length") as TreeInput
+            let dimY = ProjectSingleton.GetInstance().Tree?.FindChildByPattern("Transmitter:ShapeandElements:Y:Length") as TreeInput
+
+            freq.value = selectedPreset.frequency
+            bw.value = (selectedPreset.pb / 100) * selectedPreset.frequency
+            angle.value = selectedPreset.angle
+            dimX.value = selectedPreset.dimensions.x
+            dimY.value = selectedPreset.dimensions.y
+
+            ProjectSingleton.GetInstance().ForceRefresh()
+
+            isOpen = false
+        }
+    }
+
+    onMount(() => {
+        width = window.innerWidth
+        height = window.innerHeight
+
+        // Refresh the presets singleton every time we open this modal
+        PresetsSingleton.GetInstance().Refresh().then(() => {
+            selectedPreset = PresetsSingleton.GetInstance().Presets[0]
+        })
+    })
+
+    // Variable watcher of selectedPreset, if it changes, update some properties of buttons in the details panel, like disabled state
+    $: {
+        visitwebsiteButton.disabled = selectedPreset == null || selectedPreset.manufacturerHref == null
+        avgDgsDiagramButton.disabled = selectedPreset == null || selectedPreset.datasheetHref == null
+    }
+</script>
+
+<svelte:window bind:innerWidth={width} bind:innerHeight={height} />
+<Modal bind:isOpen={isOpen} label="Presets (Probes)" description={"Override current project settings with preset probes"} width={width < 1340 ? 6 : 4 } height={height < 900 ? 6 : 4}>
+    <!-- Dropdown selection -->
+    <div class="flex flex-row w-full">
+        <div class="flex flex-col mx-3 pb-3 w-full">
+            <label for="import_type" class="block text-sm font-medium text-gray-900 dark:text-white" style="color:#4d4d4d;">Presets</label>
+            <select id="import_type" class="bg-gray-50 border-2 border-transparent text-gray-900 text-sm rounded-md focus:border-amber-500 focus:outline-none focus:ring-0 disabled:opacity-75" bind:value={selectedPreset}>
+                {#each PresetsSingleton.GetInstance().Presets as preset}
+                    <option value={preset}>{preset.name}</option>
+                {/each}
+            </select>
+        </div>
+    </div>
+
+    <!-- Details panel -->
+    <div class="flex flex-row w-full">
+        <div class="flex flex-col mx-3 pb-3 w-6/12">
+            <p class="block text-sm font-medium text-gray-900 dark:text-white" style="color:#4d4d4d;">Details</p>
+            <p class="text-xs text-gray-900">
+                Manufacturer is <span class="font-semibold">{selectedPreset?.manufacturer}</span><br>
+                Frequency is <span class="font-semibold">{selectedPreset?.frequency}</span> MHz<br>
+                Bandwidth is <span class="font-semibold">{selectedPreset?.pb}%</span> of center frequency<br>
+                Beam angle is <span class="font-semibold">{selectedPreset?.angle}</span>°<br>
+                Dimensions are <span class="font-semibold">{selectedPreset?.dimensions.x}x{selectedPreset?.dimensions.y}</span> mm
+            </p>
+        </div>
+        <div class="flex flex-col mr-3 pt-3 pb-3 w-6/12">
+            <div class="flex flex-row rounded px-2 py-0.5 hover:bg-stone-50 self-end">
+                <Button data={visitwebsiteButton}/>
+            </div>
+            <div class="flex flex-row rounded px-2 py-0.5 hover:bg-stone-50 self-end">
+                <Button data={avgDgsDiagramButton}/>
+            </div>
+        </div>
+    </div>
+
+    <!-- Cancel/create -->
+    <div class="flex flex-row w-full p-3">
+        <div class="flex flex-col rounded px-2 py-1 hover:bg-stone-50 mr-auto">
+            <Button data={cancelButton}/>
+        </div>
+        <div class="flex flex-col rounded px-2 py-1 hover:bg-stone-50">
+            <Button data={applyButton}/>
+        </div>
+    </div>
+</Modal>

--- a/src/components/modals/PresetProbesModal.svelte
+++ b/src/components/modals/PresetProbesModal.svelte
@@ -7,6 +7,7 @@
     import type { Preset } from "../../lib/models/Preset";
     import { ProjectSingleton } from "../../lib/data/ProjectSingleton";
     import type { TreeInput } from "../../lib/models/tree/TreeInput";
+    import { open } from '@tauri-apps/api/shell';
 
     export let isOpen: boolean = false
     let width: number
@@ -20,7 +21,7 @@
         labelSize: 14, 
         action: () => {
             if (selectedPreset == null || selectedPreset.manufacturerHref == null) return
-            window.open(selectedPreset?.manufacturerHref, "_blank")
+            open(selectedPreset?.manufacturerHref);
         },
         disabled: true
     }
@@ -32,7 +33,7 @@
         labelSize: 14, 
         action: () => {
             if (selectedPreset == null || selectedPreset.datasheetHref == null) return
-            window.open(selectedPreset?.datasheetHref, "_blank")
+            open(selectedPreset?.datasheetHref);
         },
         disabled: true
     }

--- a/src/lib/data/PresetsSingleton.ts
+++ b/src/lib/data/PresetsSingleton.ts
@@ -1,0 +1,51 @@
+import { exists, readTextFile, copyFile } from "@tauri-apps/api/fs"
+import type { Preset } from "../models/Preset"
+import { SIMSUNDT_FOLDER } from "../models/PresetPaths"
+
+export class PresetsSingleton {
+    private _presets: Array<Preset>
+    private static _instance: PresetsSingleton
+
+    private constructor() {
+        this._presets = new Array<Preset>()
+
+        // Try to load the presets from the SIMSUNDT_FOLDER
+        this.Initialize()
+    }
+
+    public static GetInstance(): PresetsSingleton {
+        if (!PresetsSingleton._instance) PresetsSingleton._instance = new PresetsSingleton()
+        return PresetsSingleton._instance
+    }
+
+    public Initialize(): void {
+        // Check if the presets are already on the local disk in the SIMSUNDT_FOLDER
+        // if not, copy the default presets from the resources folder to the SIMSUNDT_FOLDER
+        // then load the presets from the SIMSUNDT_FOLDER
+        exists(`${SIMSUNDT_FOLDER}/presets.json`).then((result) => {
+            if (result) {
+                readTextFile(`${SIMSUNDT_FOLDER}/presets.json`).then((data) => {
+                    this._presets = data === null ? [] : JSON.parse(data)
+                })
+            } else {
+                copyFile(`resources/presets.json`, `${SIMSUNDT_FOLDER}/presets.json`).then(() => {
+                    readTextFile(`${SIMSUNDT_FOLDER}/presets.json`).then((data) => {
+                        this._presets = data === null ? [] : JSON.parse(data)
+                    })
+                })
+            }
+        })
+    }
+
+    public async Refresh(): Promise<void> {
+        await readTextFile(`${SIMSUNDT_FOLDER}/presets.json`).then((data) => {
+            this._presets = data === null ? [] : JSON.parse(data)
+        })
+
+        return Promise.resolve()
+    }
+
+    public get Presets(): Array<Preset> {
+        return this._presets
+    }
+}

--- a/src/lib/models/Preset.ts
+++ b/src/lib/models/Preset.ts
@@ -1,0 +1,13 @@
+export interface Preset {
+    name: string
+    manufacturer: string
+    manufacturerHref: string | null,
+    datasheetHref: string | null,
+    frequency: number
+    pb: number
+    angle: number
+    dimensions: {
+        x: number
+        y: number
+    }
+}

--- a/src/lib/validation/Rules.ts
+++ b/src/lib/validation/Rules.ts
@@ -1084,7 +1084,7 @@ export default {
         }
 
         // .. otherwise standard frequency validation applies
-        if (value as number < 0 || value as number > 12) {
+        if (value as number < 1 || value as number > 12) {
             return {
                 isValid: false,
                 isDisabled: false,
@@ -1096,11 +1096,11 @@ export default {
     },
     TransmitterSpectrumBandwidth: (value: string | number | boolean): IValidationResult => {
         // If bandwidth is higher than 12 MHz send warning
-        if (value as number < 1 || value as number > 12) {
+        if (value as number < 0.5 || value as number > 12) {
             return {
                 isValid: false,
                 isDisabled: false,
-                message: "Bandwidth is restricted from 1 to 12 MHz"
+                message: "Bandwidth is restricted from 0.5 to 12 MHz"
             };
         }
 

--- a/src/tabs/Preprocessor.svelte
+++ b/src/tabs/Preprocessor.svelte
@@ -19,6 +19,8 @@
     import type { IValidator } from "../lib/models/validation/Validator";
     import { Serialize } from "../lib/tree/Utils";
     import type TreeNode from "../lib/models/tree/TreeNode";
+    import PresetProbesModal from "../components/modals/PresetProbesModal.svelte";
+    import { bind } from "lodash";
 
     export let unsaved
     export let kernelRunner: Runner
@@ -32,6 +34,7 @@
     let treeMinimized = false
     let showConfigureModal = false
     let showParametricSettingsModal = false
+    let showPresetProbesModal = false
     let namingSchemeMethod = 1
     let namingSchemeName = ""
 
@@ -169,6 +172,26 @@
         action:  () => {showConfigureModal = false},
         disabled: false
     }
+
+    // Preset buttons
+    let materialPresetButton = {
+        label: "Materials",
+        color: "#4d4d4d",
+        icon: "inventory_2",
+        action: async () => {
+            
+        },
+        disabled: true
+    }
+    let probePresetButton = {
+        label: "Probes",
+        color: "#4d4d4d",
+        icon: "settings_remote",
+        action: () => {
+            showPresetProbesModal = true
+        },
+        disabled: false
+    }
 </script>
 
 <div id="preprocessor-tab" class="flex flex-col w-full h-full">
@@ -250,6 +273,21 @@
             <div class="flex flex-row w-full justify-center pt-7">
                 <div class="flex flex-row select-none" style="font-size:10px; color:#4d4d4d;">
                 3D View
+                </div>
+            </div>
+        </div>
+        <div class="flex flex-col line-vert my-2 mx-2"/>
+        <!-- Presets -->
+        <div class="flex flex-col w-20 pt-1 h-full -space-y-1">
+            <div class="flex flex-col mb-auto">
+                <Button data={materialPresetButton}></Button>
+            </div>
+            <div class="flex flex-col mb-auto">
+                <Button data={probePresetButton}></Button>
+            </div>
+            <div class="flex flex-row w-full justify-center pt-7">
+                <div class="flex flex-row select-none" style="font-size:10px; color:#4d4d4d;">
+                Presets
                 </div>
             </div>
         </div>
@@ -345,6 +383,7 @@
     {/if}
 
     <ParametricSettings bind:isModalOpen={showParametricSettingsModal} bind:numProcesses={projectSingleton.ProcessCount}/>
+    <PresetProbesModal bind:isOpen={showPresetProbesModal}/>
 </div>
 
 <style>


### PR DESCRIPTION
Adds the ability for the user to select probes based on real-life probes, including:
- Olympus
- IMASONIC
- SONASCAN

The user can customize their templates in their Documents/SimSUNDT/presets.json, where the data from the resources folder is copied on first initialization of the preset singleton. Supports manufacturer website and datasheet link.